### PR TITLE
Simple multisig derive macro

### DIFF
--- a/macros/src/approval/mod.rs
+++ b/macros/src/approval/mod.rs
@@ -1,0 +1,1 @@
+pub mod simple_multisig;

--- a/macros/src/approval/simple_multisig.rs
+++ b/macros/src/approval/simple_multisig.rs
@@ -42,13 +42,16 @@ pub fn expand(meta: SimpleMultisigMeta) -> Result<TokenStream, darling::Error> {
         }
 
         impl #imp ::near_contract_tools::approval::simple_multisig::AccountAuthorizer for #ident #ty #wher {
-            type AuthorizationError = ::near_contract_tools::approval::simple_multisig::macro_types::MissingRole;
+            type AuthorizationError =
+                ::near_contract_tools::approval::simple_multisig::macro_types::MissingRole<
+                    <#ident as ::near_contract_tools::rbac::Rbac>::Role
+                >;
 
             fn is_account_authorized(account_id: &AccountId) -> Result<(), Self::AuthorizationError> {
-                if <#ident as ::near_contract_tools::rbac::Rbac<_>>::has_role(account_id, &#role) {
+                if <#ident as ::near_contract_tools::rbac::Rbac>::has_role(account_id, &#role) {
                     Ok(())
                 } else {
-                    Err(::near_contract_tools::approval::simple_multisig::macro_types::MissingRole(format!("{:?}", #role)))
+                    Err(::near_contract_tools::approval::simple_multisig::macro_types::MissingRole(#role))
                 }
             }
         }

--- a/macros/src/approval/simple_multisig.rs
+++ b/macros/src/approval/simple_multisig.rs
@@ -1,0 +1,138 @@
+use std::ops::Not;
+
+use darling::{util::Flag, FromDeriveInput};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Expr;
+
+const DEFAULT_STORAGE_KEY: &str = r#"(b"~sm" as &[u8])"#;
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(nep141), supports(struct_named))]
+pub struct SimpleMultisigMeta {
+    pub storage_key: Option<Expr>,
+    pub role: Option<Expr>,
+
+    pub generics: syn::Generics,
+    pub ident: syn::Ident,
+}
+
+pub fn expand(meta: SimpleMultisigMeta) -> Result<TokenStream, darling::Error> {
+    let SimpleMultisigMeta {
+        storage_key,
+        role,
+        generics,
+        ident,
+    } = meta;
+
+    let (imp, ty, wher) = generics.split_for_impl();
+
+    let storage_key =
+        storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
+
+    Ok(quote! {
+        use ::near_contract_tools::standard::nep141::Nep141Controller;
+
+        impl #imp ::near_contract_tools::standard::nep141::Nep141Controller for #ident #ty #wher {
+            fn root(&self) -> ::near_contract_tools::slot::Slot<()> {
+                ::near_contract_tools::slot::Slot::root(#storage_key)
+            }
+        }
+
+        use ::near_contract_tools::standard::nep141::Nep141;
+
+        #[::near_sdk::near_bindgen]
+        impl #imp ::near_contract_tools::standard::nep141::Nep141 for #ident #ty #wher {
+            #[payable]
+            fn ft_transfer(
+                &mut self,
+                receiver_id: ::near_sdk::AccountId,
+                amount: ::near_sdk::json_types::U128,
+                memo: Option<String>,
+            ) {
+                use ::near_contract_tools::{
+                    event::Event,
+                    standard::nep141::{Nep141Controller, Nep141Event},
+                };
+
+                ::near_sdk::assert_one_yocto();
+                let sender_id = ::near_sdk::env::predecessor_account_id();
+                let amount: u128 = amount.into();
+
+                let transfer = ::near_contract_tools::standard::nep141::Nep141Transfer {
+                    sender_id: sender_id.clone(),
+                    receiver_id: receiver_id.clone(),
+                    amount,
+                    memo: memo.clone(),
+                    msg: None,
+                };
+
+                #before_transfer
+
+                Nep141Controller::transfer(self, &sender_id, &receiver_id, amount, memo.as_deref());
+
+                #after_transfer
+            }
+
+            #[payable]
+            fn ft_transfer_call(
+                &mut self,
+                receiver_id: ::near_sdk::AccountId,
+                amount: ::near_sdk::json_types::U128,
+                memo: Option<String>,
+                msg: String,
+            ) -> ::near_sdk::Promise {
+                ::near_sdk::assert_one_yocto();
+                let sender_id = ::near_sdk::env::predecessor_account_id();
+                let amount: u128 = amount.into();
+
+                let transfer = ::near_contract_tools::standard::nep141::Nep141Transfer {
+                    sender_id: sender_id.clone(),
+                    receiver_id: receiver_id.clone(),
+                    amount,
+                    memo: memo.clone(),
+                    msg: None,
+                };
+
+                #before_transfer
+
+                let r = ::near_contract_tools::standard::nep141::Nep141Controller::transfer_call(
+                    self,
+                    sender_id.clone(),
+                    receiver_id.clone(),
+                    amount,
+                    memo.as_deref(),
+                    msg.clone(),
+                    near_sdk::env::prepaid_gas(),
+                );
+
+                #after_transfer
+
+                r
+            }
+
+            fn ft_total_supply(&self) -> ::near_sdk::json_types::U128 {
+                ::near_contract_tools::standard::nep141::Nep141Controller::total_supply(self).into()
+            }
+
+            fn ft_balance_of(&self, account_id: ::near_sdk::AccountId) -> near_sdk::json_types::U128 {
+                ::near_contract_tools::standard::nep141::Nep141Controller::balance_of(self, &account_id).into()
+            }
+        }
+
+        use ::near_contract_tools::standard::nep141::Nep141Resolver;
+
+        #[::near_sdk::near_bindgen]
+        impl #imp ::near_contract_tools::standard::nep141::Nep141Resolver for #ident #ty #wher {
+            #[private]
+            fn ft_resolve_transfer(
+                &mut self,
+                sender_id: ::near_sdk::AccountId,
+                receiver_id: ::near_sdk::AccountId,
+                amount: ::near_sdk::json_types::U128,
+            ) -> ::near_sdk::json_types::U128 {
+                ::near_contract_tools::standard::nep141::Nep141Controller::resolve_transfer(self, sender_id, receiver_id, amount.into()).into()
+            }
+        }
+    })
+}

--- a/macros/src/approval/simple_multisig.rs
+++ b/macros/src/approval/simple_multisig.rs
@@ -1,6 +1,4 @@
-use std::ops::Not;
-
-use darling::{util::Flag, FromDeriveInput};
+use darling::FromDeriveInput;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Expr;
@@ -8,10 +6,11 @@ use syn::Expr;
 const DEFAULT_STORAGE_KEY: &str = r#"(b"~sm" as &[u8])"#;
 
 #[derive(Debug, FromDeriveInput)]
-#[darling(attributes(nep141), supports(struct_named))]
+#[darling(attributes(simple_multisig), supports(struct_named))]
 pub struct SimpleMultisigMeta {
     pub storage_key: Option<Expr>,
-    pub role: Option<Expr>,
+    pub action: Expr,
+    pub role: Expr,
 
     pub generics: syn::Generics,
     pub ident: syn::Ident,
@@ -20,6 +19,7 @@ pub struct SimpleMultisigMeta {
 pub fn expand(meta: SimpleMultisigMeta) -> Result<TokenStream, darling::Error> {
     let SimpleMultisigMeta {
         storage_key,
+        action,
         role,
         generics,
         ident,
@@ -31,107 +31,37 @@ pub fn expand(meta: SimpleMultisigMeta) -> Result<TokenStream, darling::Error> {
         storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
 
     Ok(quote! {
-        use ::near_contract_tools::standard::nep141::Nep141Controller;
-
-        impl #imp ::near_contract_tools::standard::nep141::Nep141Controller for #ident #ty #wher {
-            fn root(&self) -> ::near_contract_tools::slot::Slot<()> {
+        impl #imp ::near_contract_tools::approval::ApprovalManager<
+                #action,
+                ::near_contract_tools::approval::simple_multisig::ApprovalState,
+                ::near_contract_tools::approval::simple_multisig::Configuration<Self>,
+            > for #ident #ty #wher {
+            fn root() -> ::near_contract_tools::slot::Slot<()> {
                 ::near_contract_tools::slot::Slot::root(#storage_key)
             }
         }
 
-        use ::near_contract_tools::standard::nep141::Nep141;
+        // TODO: This pollutes the global namespace. Is there some better strategy?
+        #[derive(Debug, PartialEq)]
+        pub enum AccountApproverError {
+            UnauthorizedAccount,
+        }
 
-        #[::near_sdk::near_bindgen]
-        impl #imp ::near_contract_tools::standard::nep141::Nep141 for #ident #ty #wher {
-            #[payable]
-            fn ft_transfer(
-                &mut self,
-                receiver_id: ::near_sdk::AccountId,
-                amount: ::near_sdk::json_types::U128,
-                memo: Option<String>,
-            ) {
-                use ::near_contract_tools::{
-                    event::Event,
-                    standard::nep141::{Nep141Controller, Nep141Event},
-                };
-
-                ::near_sdk::assert_one_yocto();
-                let sender_id = ::near_sdk::env::predecessor_account_id();
-                let amount: u128 = amount.into();
-
-                let transfer = ::near_contract_tools::standard::nep141::Nep141Transfer {
-                    sender_id: sender_id.clone(),
-                    receiver_id: receiver_id.clone(),
-                    amount,
-                    memo: memo.clone(),
-                    msg: None,
-                };
-
-                #before_transfer
-
-                Nep141Controller::transfer(self, &sender_id, &receiver_id, amount, memo.as_deref());
-
-                #after_transfer
-            }
-
-            #[payable]
-            fn ft_transfer_call(
-                &mut self,
-                receiver_id: ::near_sdk::AccountId,
-                amount: ::near_sdk::json_types::U128,
-                memo: Option<String>,
-                msg: String,
-            ) -> ::near_sdk::Promise {
-                ::near_sdk::assert_one_yocto();
-                let sender_id = ::near_sdk::env::predecessor_account_id();
-                let amount: u128 = amount.into();
-
-                let transfer = ::near_contract_tools::standard::nep141::Nep141Transfer {
-                    sender_id: sender_id.clone(),
-                    receiver_id: receiver_id.clone(),
-                    amount,
-                    memo: memo.clone(),
-                    msg: None,
-                };
-
-                #before_transfer
-
-                let r = ::near_contract_tools::standard::nep141::Nep141Controller::transfer_call(
-                    self,
-                    sender_id.clone(),
-                    receiver_id.clone(),
-                    amount,
-                    memo.as_deref(),
-                    msg.clone(),
-                    near_sdk::env::prepaid_gas(),
-                );
-
-                #after_transfer
-
-                r
-            }
-
-            fn ft_total_supply(&self) -> ::near_sdk::json_types::U128 {
-                ::near_contract_tools::standard::nep141::Nep141Controller::total_supply(self).into()
-            }
-
-            fn ft_balance_of(&self, account_id: ::near_sdk::AccountId) -> near_sdk::json_types::U128 {
-                ::near_contract_tools::standard::nep141::Nep141Controller::balance_of(self, &account_id).into()
+        impl ::std::fmt::Display for AccountApproverError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                ::std::write!(f, "Unauthorized account")
             }
         }
 
-        use ::near_contract_tools::standard::nep141::Nep141Resolver;
+        impl #imp ::near_contract_tools::approval::simple_multisig::AccountApprover for #ident #ty #wher {
+            type Error = AccountApproverError;
 
-        #[::near_sdk::near_bindgen]
-        impl #imp ::near_contract_tools::standard::nep141::Nep141Resolver for #ident #ty #wher {
-            #[private]
-            fn ft_resolve_transfer(
-                &mut self,
-                sender_id: ::near_sdk::AccountId,
-                receiver_id: ::near_sdk::AccountId,
-                amount: ::near_sdk::json_types::U128,
-            ) -> ::near_sdk::json_types::U128 {
-                ::near_contract_tools::standard::nep141::Nep141Controller::resolve_transfer(self, sender_id, receiver_id, amount.into()).into()
+            fn approve_account(account_id: &::near_sdk::AccountId) -> Result<(), AccountApproverError> {
+                if <#ident as ::near_contract_tools::rbac::Rbac<_>>::has_role(account_id, &#role) {
+                    Ok(())
+                } else {
+                    Err(AccountApproverError::UnauthorizedAccount)
+                }
             }
         }
     })

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -2,6 +2,7 @@ use darling::FromDeriveInput;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
+mod approval;
 mod event;
 mod migrate;
 mod owner;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -129,3 +129,19 @@ pub fn derive_fungible_token(input: TokenStream) -> TokenStream {
 pub fn derive_migrate(input: TokenStream) -> TokenStream {
     make_derive(input, migrate::expand)
 }
+
+/// Create a simple multisig component. Does not expose any functions to the
+/// blockchain. Creates implementations for `ApprovalManager` and
+/// `AccountApprover` for the target contract struct.
+///
+/// Fields may be specified in the `#[simple_multisig(...)]` attribute.
+///
+/// Fields include:
+///  - `storage_key` Storage prefix for multisig data (optional, default: `b"~sm"`)
+///  - `action` What sort of approval `Action` can be approved by the multisig
+///     component?
+///  - `role` Approving accounts are required to have this `Rbac` role.
+#[proc_macro_derive(SimpleMultisig, attributes(simple_multisig))]
+pub fn derive_simple_multisig(input: TokenStream) -> TokenStream {
+    make_derive(input, approval::simple_multisig::expand)
+}

--- a/src/approval/simple_multisig.rs
+++ b/src/approval/simple_multisig.rs
@@ -200,7 +200,7 @@ pub mod macro_types {
     /// Account that attempted an action is missing a role
     #[derive(Error, Clone, Debug)]
     #[error("Missing role '{0}' required for this action")]
-    pub struct MissingRole(pub String);
+    pub struct MissingRole<R>(pub R);
 }
 
 #[cfg(test)]

--- a/workspaces-tests/src/bin/native_multisig.rs
+++ b/workspaces-tests/src/bin/native_multisig.rs
@@ -18,7 +18,7 @@ use near_sdk::{
 };
 
 #[derive(Clone, Debug, BorshSerialize, BorshStorageKey)]
-enum Role {
+pub enum Role {
     Multisig,
 }
 

--- a/workspaces-tests/src/bin/simple_multisig.rs
+++ b/workspaces-tests/src/bin/simple_multisig.rs
@@ -44,7 +44,7 @@ impl approval::Action for MyAction {
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshStorageKey)]
-enum Role {
+pub enum Role {
     Multisig,
 }
 

--- a/workspaces-tests/tests/native_multisig.rs
+++ b/workspaces-tests/tests/native_multisig.rs
@@ -40,19 +40,18 @@ async fn setup(num_accounts: usize) -> Setup {
 async fn setup_roles(num_accounts: usize) -> Setup {
     let s = setup(num_accounts).await;
 
-    // for account in s.accounts[..s.accounts.len() - 1].iter() {
-    //     account
-    //         .call(&s.worker, s.contract.id(), "obtain_multisig_permission")
-    //         .transact()
-    //         .await
-    //         .unwrap();
-    // }
+    for account in s.accounts[..s.accounts.len() - 1].iter() {
+        account
+            .call(&s.worker, s.contract.id(), "obtain_multisig_permission")
+            .transact()
+            .await
+            .unwrap();
+    }
 
     s
 }
 
 #[tokio::test]
-// #[ignore] // TODO: Remove
 async fn transfer() {
     let Setup {
         worker,
@@ -146,7 +145,6 @@ async fn transfer() {
 }
 
 #[tokio::test]
-// #[ignore] // TODO: Remove
 async fn reflexive_xcc() {
     let Setup {
         worker,


### PR DESCRIPTION
Writes a decent amount of the boilerplate per discussion with @nearken . Does not expose a public interface (difficult with generics + NEP requirement). Usage: see updated workspaces test.