### PR TITLE
`Action::execute` takes mutable contract reference

### DIFF
--- a/src/approval/native_transaction_action.rs
+++ b/src/approval/native_transaction_action.rs
@@ -86,10 +86,10 @@ pub struct NativeTransactionAction {
     pub actions: Vec<PromiseAction>,
 }
 
-impl super::Action for NativeTransactionAction {
+impl<C> super::Action<C> for NativeTransactionAction {
     type Output = Promise;
 
-    fn execute(self) -> Self::Output {
+    fn execute(self, _contract: &mut C) -> Self::Output {
         let mut promise = Promise::new(self.receiver_id);
 
         // Construct promise

--- a/src/approval/simple_multisig.rs
+++ b/src/approval/simple_multisig.rs
@@ -230,10 +230,10 @@ mod tests {
         SayGoodbye,
     }
 
-    impl crate::approval::Action for Action {
+    impl crate::approval::Action<Contract> for Action {
         type Output = &'static str;
 
-        fn execute(self) -> Self::Output {
+        fn execute(self, _contract: &mut Contract) -> Self::Output {
             match self {
                 Self::SayHello => "hello",
                 Self::SayGoodbye => "goodbye",

--- a/workspaces-tests/Cargo.toml
+++ b/workspaces-tests/Cargo.toml
@@ -5,6 +5,9 @@ name = "workspaces-tests"
 version = "0.1.0"
 
 [[bin]]
+name = "counter_multisig"
+
+[[bin]]
 name = "cross_target"
 
 [[bin]]
@@ -19,6 +22,8 @@ name = "simple_multisig"
 [dependencies]
 near-contract-tools = {path = "../"}
 near-sdk = "4.0.0"
+strum = "0.24.1"
+strum_macros = "0.24.3"
 thiserror = "1.0.34"
 
 [dev-dependencies]

--- a/workspaces-tests/src/bin/counter_multisig.rs
+++ b/workspaces-tests/src/bin/counter_multisig.rs
@@ -1,0 +1,123 @@
+#![allow(missing_docs)]
+
+use near_contract_tools::{
+    approval::{simple_multisig::Configuration, *},
+    rbac::Rbac,
+    Rbac, SimpleMultisig,
+};
+use near_sdk::{
+    borsh::{self, BorshDeserialize, BorshSerialize},
+    env, near_bindgen,
+    serde::Serialize,
+    BorshStorageKey, PanicOnDefault,
+};
+use std::string::ToString;
+use strum_macros::Display;
+
+#[derive(BorshSerialize, BorshStorageKey, Clone, Debug, Display)]
+pub enum Role {
+    Member,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize)]
+#[serde(crate = "near_sdk::serde")]
+pub enum CounterAction {
+    Increment,
+    Decrement,
+    Reset,
+}
+
+impl Action<Contract> for CounterAction {
+    type Output = u32;
+
+    fn execute(self, contract: &mut Contract) -> Self::Output {
+        match self {
+            CounterAction::Increment => {
+                contract.counter += 1;
+            }
+            CounterAction::Decrement => {
+                contract.counter -= 1;
+            }
+            CounterAction::Reset => {
+                contract.counter = 0;
+            }
+        }
+
+        contract.counter
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, PanicOnDefault, Rbac, SimpleMultisig)]
+#[simple_multisig(action = "CounterAction", role = "Role::Member")]
+#[rbac(roles = "Role")]
+#[near_bindgen]
+pub struct Contract {
+    pub counter: u32,
+}
+
+#[near_bindgen]
+impl Contract {
+    const THRESHOLD: u8 = 2;
+    const VALIDITY_PERIOD_NANOSECONDS: u64 = 1_000_000 * 1_000 * 60 * 60 * 24 * 7;
+
+    #[init]
+    pub fn new() -> Self {
+        <Self as ApprovalManager<_, _, _>>::init(Configuration::new(
+            Self::THRESHOLD,
+            Self::VALIDITY_PERIOD_NANOSECONDS,
+        ));
+
+        Self { counter: 0 }
+    }
+
+    pub fn obtain_multisig_permission(&mut self) {
+        self.add_role(&env::predecessor_account_id(), &Role::Member);
+    }
+
+    pub fn request_increment(&mut self) -> u32 {
+        self.create_request(CounterAction::Increment, Default::default())
+            .map_err(|e| env::panic_str(&e.to_string()))
+            .unwrap()
+    }
+
+    pub fn request_decrement(&mut self) -> u32 {
+        self.create_request(CounterAction::Decrement, Default::default())
+            .map_err(|e| env::panic_str(&e.to_string()))
+            .unwrap()
+    }
+
+    pub fn request_reset(&mut self) -> u32 {
+        self.create_request(CounterAction::Reset, Default::default())
+            .map_err(|e| env::panic_str(&e.to_string()))
+            .unwrap()
+    }
+
+    pub fn approve(&mut self, request_id: u32) {
+        self.approve_request(request_id)
+            .map_err(|e| env::panic_str(&e.to_string()))
+            .unwrap()
+    }
+
+    pub fn get_request(
+        &self,
+        request_id: u32,
+    ) -> Option<ActionRequest<CounterAction, simple_multisig::ApprovalState>> {
+        <Self as ApprovalManager<_, _, _>>::get_request(request_id)
+    }
+
+    pub fn is_approved(&self, request_id: u32) -> bool {
+        <Self as ApprovalManager<_, _, _>>::is_approved_for_execution(request_id).is_ok()
+    }
+
+    pub fn execute(&mut self, request_id: u32) -> u32 {
+        self.execute_request(request_id)
+            .map_err(|e| env::panic_str(&e.to_string()))
+            .unwrap()
+    }
+
+    pub fn get_counter(&self) -> u32 {
+        self.counter
+    }
+}
+
+pub fn main() {} // Ignore

--- a/workspaces-tests/src/bin/simple_multisig.rs
+++ b/workspaces-tests/src/bin/simple_multisig.rs
@@ -32,10 +32,10 @@ enum MyAction {
     SayGoodbye,
 }
 
-impl approval::Action for MyAction {
+impl approval::Action<Contract> for MyAction {
     type Output = &'static str;
 
-    fn execute(self) -> Self::Output {
+    fn execute(self, _contract: &mut Contract) -> Self::Output {
         match self {
             Self::SayHello => "hello",
             Self::SayGoodbye => "goodbye",

--- a/workspaces-tests/tests/counter_multisig.rs
+++ b/workspaces-tests/tests/counter_multisig.rs
@@ -1,0 +1,170 @@
+#![cfg(not(windows))]
+
+use near_sdk::serde_json::json;
+use workspaces::{network::Sandbox, prelude::*, Account, Contract, Worker};
+
+const WASM: &[u8] =
+    include_bytes!("../../target/wasm32-unknown-unknown/release/counter_multisig.wasm");
+
+struct Setup {
+    pub worker: Worker<Sandbox>,
+    pub contract: Contract,
+    pub accounts: Vec<Account>,
+}
+
+/// Setup for individual tests
+async fn setup(num_accounts: usize) -> Setup {
+    let worker = workspaces::sandbox().await.unwrap();
+
+    // Initialize contract
+    let contract = worker.dev_deploy(&WASM.to_vec()).await.unwrap();
+    contract.call(&worker, "new").transact().await.unwrap();
+
+    // Initialize user accounts
+    let mut accounts = vec![];
+    for _ in 0..(num_accounts + 1) {
+        accounts.push(worker.dev_create_account().await.unwrap());
+    }
+
+    Setup {
+        worker,
+        contract,
+        accounts,
+    }
+}
+
+async fn setup_roles(num_accounts: usize) -> Setup {
+    let s = setup(num_accounts).await;
+
+    for account in s.accounts[..s.accounts.len() - 1].iter() {
+        account
+            .call(&s.worker, s.contract.id(), "obtain_multisig_permission")
+            .transact()
+            .await
+            .unwrap();
+    }
+
+    s
+}
+
+#[tokio::test]
+async fn success() {
+    let Setup {
+        worker,
+        contract,
+        accounts,
+    } = setup_roles(3).await;
+
+    let alice = &accounts[0];
+    let bob = &accounts[1];
+    let charlie = &accounts[2];
+
+    let create_request = |account: &Account, fname: &str| {
+        let worker = worker.clone();
+        let fname = fname.to_string();
+        let account = account.clone();
+        let contract_id = contract.id();
+        async move {
+            account
+                .clone()
+                .call(&worker, contract_id, &fname)
+                .transact()
+                .await
+                .unwrap()
+                .json::<u32>()
+                .unwrap()
+        }
+    };
+
+    // Increment
+    let request_id = create_request(alice, "request_increment").await;
+
+    let is_approved = |request_id: u32| {
+        let view = contract.view(
+            &worker,
+            "is_approved",
+            json!({ "request_id": request_id })
+                .to_string()
+                .as_bytes()
+                .to_vec(),
+        );
+        async move { view.await.unwrap().json::<bool>().unwrap() }
+    };
+
+    assert!(!is_approved(request_id).await);
+
+    let approve = |account: &Account, request_id: u32| {
+        let transact = account
+            .call(&worker, contract.id(), "approve")
+            .args_json(json!({ "request_id": request_id }))
+            .unwrap()
+            .transact();
+        async move { transact.await.unwrap() }
+    };
+
+    approve(alice, request_id).await;
+
+    assert!(!is_approved(request_id).await);
+
+    approve(bob, request_id).await;
+
+    assert!(is_approved(request_id).await);
+
+    approve(charlie, request_id).await;
+
+    assert!(is_approved(request_id).await);
+
+    let get_counter = || async {
+        contract
+            .view(&worker, "get_counter", vec![])
+            .await
+            .unwrap()
+            .json::<u32>()
+            .unwrap()
+    };
+
+    let counter = get_counter().await;
+
+    assert_eq!(counter, 0);
+
+    let execute = |account: &Account, request_id: u32| {
+        let transact = account
+            .call(&worker, contract.id(), "execute")
+            .args_json(json!({ "request_id": request_id }))
+            .unwrap()
+            .transact();
+        async move { transact.await.unwrap().json::<u32>().unwrap() }
+    };
+
+    let result = execute(alice, request_id).await;
+
+    assert_eq!(result, 1);
+
+    let counter = get_counter().await;
+
+    assert_eq!(counter, 1);
+
+    let request_id = create_request(bob, "request_increment").await;
+    approve(bob, request_id).await;
+    approve(alice, request_id).await;
+    let result = execute(bob, request_id).await;
+    let counter = get_counter().await;
+    assert_eq!(result, counter);
+    assert_eq!(counter, 2);
+
+    let request_id = create_request(charlie, "request_decrement").await;
+    approve(bob, request_id).await;
+    approve(charlie, request_id).await;
+    let result = execute(alice, request_id).await;
+    let counter = get_counter().await;
+    assert_eq!(result, counter);
+    assert_eq!(counter, 1);
+
+    let request_id = create_request(charlie, "request_reset").await;
+    approve(bob, request_id).await;
+    approve(alice, request_id).await;
+    let result = execute(alice, request_id).await;
+    let counter = get_counter().await;
+    assert_eq!(result, counter);
+    assert_eq!(counter, 0);
+}


### PR DESCRIPTION
Makes it easier to create custom `Action`s that simply perform an internal action (rather than a promise -> function call chain which is more complicated and expensive). See new workspaces test for example.