### PR TITLE
Improve events

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,8 +1,8 @@
 //! Macros for near-contract-tools
 
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, AttributeArgs, DeriveInput};
 
 mod approval;
 mod event;
@@ -146,4 +146,15 @@ pub fn derive_migrate(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(SimpleMultisig, attributes(simple_multisig))]
 pub fn derive_simple_multisig(input: TokenStream) -> TokenStream {
     make_derive(input, approval::simple_multisig::expand)
+}
+
+/// Smart #[event] macro
+#[proc_macro_attribute]
+pub fn to_event(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr as AttributeArgs);
+
+    event::EventAttributeMeta::from_list(&attr)
+        .map(|meta| event::event_attribute(meta, item.into()))
+        .map(Into::into)
+        .unwrap_or_else(|e| e.write_errors().into())
 }

--- a/macros/src/rename.rs
+++ b/macros/src/rename.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use darling::FromMeta;
 use heck::{
     ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase, ToTitleCase,
@@ -34,6 +36,24 @@ impl FromMeta for RenameStrategy {
     fn from_string(value: &str) -> darling::Result<Self> {
         RenameStrategy::try_from(value)
             .map_err(|_| darling::Error::custom("Invalid rename strategy"))
+    }
+}
+
+impl Display for RenameStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                RenameStrategy::UpperCamelCase => "UpperCamelCase",
+                RenameStrategy::LowerCamelCase => "lowerCamelCase",
+                RenameStrategy::SnakeCase => "snake_case",
+                RenameStrategy::KebabCase => "kebab-case",
+                RenameStrategy::ShoutySnakeCase => "SHOUTY_SNAKE_CASE",
+                RenameStrategy::TitleCase => "Title Case",
+                RenameStrategy::ShoutyKebabCase => "SHOUTY-KEBAB-CASE",
+            },
+        )
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -43,7 +43,7 @@ pub trait EventMetadata {
 
 /// NEP-297 Event Log Data
 /// <https://github.com/near/NEPs/blob/master/neps/nep-0297.md#specification>
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 struct EventLogData<'a, T> {
     pub standard: &'a str,
     pub version: &'a str,

--- a/tests/macros/event.rs
+++ b/tests/macros/event.rs
@@ -40,3 +40,25 @@ fn derive_event() {
 
     assert_eq!(Nep171::CustomEvent.event(), "CUSTOM-EVENT");
 }
+
+mod event_attribute_macro {
+    use near_contract_tools::{event::Event, to_event};
+
+    #[to_event(standard = "my_event_standard", version = "1")]
+    #[allow(unused)]
+    enum MyEvent {
+        One,
+        ThreePointFive { foo: &'static str },
+        Six,
+    }
+
+    #[test]
+    fn test() {
+        let e = MyEvent::ThreePointFive { foo: "hello" };
+        e.emit();
+        assert_eq!(
+            e.to_string(),
+            r#"EVENT_JSON:{"standard":"my_event_standard","version":"1","event":"three_point_five","data":{"foo":"hello"}}"#,
+        );
+    }
+}


### PR DESCRIPTION
- cannot derive `Display` directly on `Event`s, since `Event` is a trait and `Display` is a foreign trait
- `#[to_event]` does a lot of the stuff you'd usually have to do when deriving `Event`