### PR TITLE
Specify crate in every macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,26 @@ impl Nep141Hook for Contract {
 
 Note: Hooks can be disabled using `#[nep141(no_hooks)]` or `#[fungible_token(no_hooks)]`.
 
+### Custom Crates
+
+If you are a library developer, have modified a crate that one of the `near-contract-tools` macros uses (like `serde` or `near-sdk`), or are otherwise using a crate under a different name, you can specify crate names in macros like so:
+
+```rust, ignore
+#[event(
+    // ...
+    crate = "near_contract_tools",
+    macros = "near_contract_tools_macros",
+    serde = "serde",
+)]
+// ...
+
+#[derive(Owner)]
+#[owner(
+    // ...
+    near_sdk = "near_sdk",
+)]
+```
+
 ## Other Tips
 
 ### [Internal vs External Methods](https://youtu.be/kJzes_UP5j0?t=2172)

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -12,6 +12,22 @@ mod rbac;
 mod rename;
 mod standard;
 
+fn default_crate_name() -> syn::Path {
+    syn::parse_str("::near_contract_tools").unwrap()
+}
+
+fn default_macros() -> syn::Path {
+    syn::parse_str("::near_contract_tools").unwrap()
+}
+
+fn default_near_sdk() -> syn::Path {
+    syn::parse_str("::near_sdk").unwrap()
+}
+
+fn default_serde() -> syn::Path {
+    syn::parse_str("::serde").unwrap()
+}
+
 fn make_derive<T>(
     input: TokenStream,
     expand: fn(T) -> Result<proc_macro2::TokenStream, darling::Error>,
@@ -153,7 +169,7 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = parse_macro_input!(attr as AttributeArgs);
 
     standard::event::EventAttributeMeta::from_list(&attr)
-        .map(|meta| standard::event::event_attribute(meta, item.into()))
+        .and_then(|meta| standard::event::event_attribute(meta, item.into()))
         .map(Into::into)
         .unwrap_or_else(|e| e.write_errors().into())
 }

--- a/macros/src/migrate.rs
+++ b/macros/src/migrate.rs
@@ -10,6 +10,12 @@ pub struct MigrateMeta {
 
     pub ident: syn::Ident,
     pub generics: syn::Generics,
+
+    // crates
+    #[darling(rename = "crate", default = "crate::default_crate_name")]
+    pub me: syn::Path,
+    #[darling(default = "crate::default_near_sdk")]
+    pub near_sdk: syn::Path,
 }
 
 pub fn expand(meta: MigrateMeta) -> Result<TokenStream, darling::Error> {
@@ -19,6 +25,9 @@ pub fn expand(meta: MigrateMeta) -> Result<TokenStream, darling::Error> {
 
         ident,
         generics,
+
+        me,
+        near_sdk,
     } = meta;
 
     let (imp, ty, wh) = generics.split_for_impl();
@@ -28,18 +37,18 @@ pub fn expand(meta: MigrateMeta) -> Result<TokenStream, darling::Error> {
         .unwrap_or_else(|| quote! { Self }.to_token_stream());
 
     Ok(quote! {
-        impl #imp ::near_contract_tools::migrate::MigrateController for #ident #ty #wh {
+        impl #imp #me::migrate::MigrateController for #ident #ty #wh {
             type OldSchema = #from;
             type NewSchema = #to;
         }
 
-        #[::near_sdk::near_bindgen]
-        impl #imp ::near_contract_tools::migrate::MigrateExternal for #ident #ty #wh {
+        #[#near_sdk::near_bindgen]
+        impl #imp #me::migrate::MigrateExternal for #ident #ty #wh {
             #[init(ignore_state)]
             fn migrate(args: Option<String>) -> Self {
-                let old_state = <#ident as ::near_contract_tools::migrate::MigrateController>::deserialize_old_schema();
+                let old_state = <#ident as #me::migrate::MigrateController>::deserialize_old_schema();
 
-                <#ident as ::near_contract_tools::migrate::MigrateHook>::migrate(
+                <#ident as #me::migrate::MigrateHook>::migrate(
                     old_state,
                     args,
                 )

--- a/macros/src/pause.rs
+++ b/macros/src/pause.rs
@@ -10,26 +10,42 @@ const DEFAULT_STORAGE_KEY: &str = r#"(b"~p" as &[u8])"#;
 pub struct PauseMeta {
     pub storage_key: Option<Expr>,
 
+    pub generics: syn::Generics,
     pub ident: syn::Ident,
+
+    // crates
+    #[darling(rename = "crate", default = "crate::default_crate_name")]
+    pub me: syn::Path,
+    #[darling(default = "crate::default_near_sdk")]
+    pub near_sdk: syn::Path,
 }
 
 pub fn expand(meta: PauseMeta) -> Result<TokenStream, darling::Error> {
-    let PauseMeta { storage_key, ident } = meta;
+    let PauseMeta {
+        storage_key,
+        ident,
+        generics,
+
+        me,
+        near_sdk,
+    } = meta;
+
+    let (imp, ty, wher) = generics.split_for_impl();
 
     let storage_key =
         storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
 
     Ok(quote! {
-        impl near_contract_tools::pause::Pause for #ident {
-            fn root() -> near_contract_tools::slot::Slot<()> {
-                near_contract_tools::slot::Slot::new(#storage_key)
+        impl #imp #me::pause::Pause for #ident #ty #wher {
+            fn root() -> #me::slot::Slot<()> {
+                #me::slot::Slot::new(#storage_key)
             }
         }
 
-        #[near_sdk::near_bindgen]
-        impl near_contract_tools::pause::PauseExternal for #ident {
+        #[#near_sdk::near_bindgen]
+        impl #imp #me::pause::PauseExternal for #ident #ty #wher {
             fn paus_is_paused(&self) -> bool {
-                <Self as near_contract_tools::pause::Pause>::is_paused()
+                <Self as #me::pause::Pause>::is_paused()
             }
         }
     })

--- a/macros/src/rbac.rs
+++ b/macros/src/rbac.rs
@@ -11,25 +11,37 @@ pub struct RbacMeta {
     pub storage_key: Option<Expr>,
     pub roles: Expr,
 
+    // darling
     pub ident: syn::Ident,
+    pub generics: syn::Generics,
+
+    // crates
+    #[darling(rename = "crate", default = "crate::default_crate_name")]
+    pub me: syn::Path,
 }
 
 pub fn expand(meta: RbacMeta) -> Result<TokenStream, darling::Error> {
     let RbacMeta {
         storage_key,
         roles,
+
         ident,
+        generics,
+
+        me,
     } = meta;
+
+    let (imp, ty, wher) = generics.split_for_impl();
 
     let storage_key =
         storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
 
     Ok(quote! {
-        impl near_contract_tools::rbac::Rbac for #ident {
+        impl #imp #me::rbac::Rbac for #ident #ty #wher {
             type Role = #roles;
 
-            fn root() -> near_contract_tools::slot::Slot<()> {
-                near_contract_tools::slot::Slot::new(#storage_key)
+            fn root() -> #me::slot::Slot<()> {
+                #me::slot::Slot::new(#storage_key)
             }
         }
     })

--- a/macros/src/standard/event.rs
+++ b/macros/src/standard/event.rs
@@ -10,30 +10,39 @@ pub struct EventAttributeMeta {
     pub version: String,
     pub rename_all: Option<RenameStrategy>,
 
-    /// serde crate path
-    pub serde: Option<syn::Expr>,
+    // pub me: String,
+    // pub macros: String,
+    // pub serde: String,
+    #[darling(rename = "crate", default = "crate::default_crate_name")]
+    pub me: syn::Path,
+    #[darling(default = "crate::default_macros")]
+    pub macros: syn::Path,
+    #[darling(default = "crate::default_serde")]
+    pub serde: syn::Path,
 }
 
-pub fn event_attribute(attr: EventAttributeMeta, item: TokenStream) -> TokenStream {
+pub fn event_attribute(
+    attr: EventAttributeMeta,
+    item: TokenStream,
+) -> Result<TokenStream, darling::Error> {
     let EventAttributeMeta {
         standard,
         version,
         rename_all,
         serde,
+        me,
+        macros,
     } = attr;
 
     let rename_all = rename_all.unwrap_or(RenameStrategy::SnakeCase).to_string();
 
-    let serde = serde
-        .map(|s| quote! { #s })
-        .unwrap_or_else(|| quote! { ::serde });
+    let serde_str = quote! { #serde }.to_string();
+    let me_str = quote! { #me }.to_string();
 
-    let serde_str = serde.to_string();
-
-    quote::quote! {
-        #[derive(near_contract_tools::Nep297, #serde :: Serialize)]
-        #[nep297(standard = #standard, version = #version, rename_all = #rename_all)]
+    Ok(quote::quote! {
+        #[derive(#macros::Nep297, #serde::Serialize)]
+        #[nep297(standard = #standard, version = #version, rename_all = #rename_all, crate = #me_str)]
         #[serde(crate = #serde_str, untagged)]
         #item
-    }
+    })
 }

--- a/macros/src/standard/fungible_token.rs
+++ b/macros/src/standard/fungible_token.rs
@@ -24,6 +24,12 @@ pub struct FungibleTokenMeta {
     // darling
     pub generics: syn::Generics,
     pub ident: syn::Ident,
+
+    // crates
+    #[darling(rename = "crate", default = "crate::default_crate_name")]
+    pub me: syn::Path,
+    #[darling(default = "crate::default_near_sdk")]
+    pub near_sdk: syn::Path,
 }
 
 pub fn expand(meta: FungibleTokenMeta) -> Result<TokenStream, darling::Error> {
@@ -41,6 +47,9 @@ pub fn expand(meta: FungibleTokenMeta) -> Result<TokenStream, darling::Error> {
 
         generics,
         ident,
+
+        me,
+        near_sdk,
     } = meta;
 
     let expand_nep141 = nep141::expand(nep141::Nep141Meta {
@@ -49,6 +58,9 @@ pub fn expand(meta: FungibleTokenMeta) -> Result<TokenStream, darling::Error> {
 
         generics: generics.clone(),
         ident: ident.clone(),
+
+        me: me.clone(),
+        near_sdk: near_sdk.clone(),
     });
 
     let expand_nep148 = nep148::expand(nep148::Nep148Meta {
@@ -62,6 +74,9 @@ pub fn expand(meta: FungibleTokenMeta) -> Result<TokenStream, darling::Error> {
 
         generics,
         ident,
+
+        me,
+        near_sdk,
     });
 
     let mut e = darling::Error::accumulator();

--- a/macros/src/standard/nep141.rs
+++ b/macros/src/standard/nep141.rs
@@ -14,6 +14,12 @@ pub struct Nep141Meta {
     pub no_hooks: Flag,
     pub generics: syn::Generics,
     pub ident: syn::Ident,
+
+    // crates
+    #[darling(rename = "crate", default = "crate::default_crate_name")]
+    pub me: syn::Path,
+    #[darling(default = "crate::default_near_sdk")]
+    pub near_sdk: syn::Path,
 }
 
 pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
@@ -22,6 +28,9 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
         no_hooks,
         generics,
         ident,
+
+        me,
+        near_sdk,
     } = meta;
 
     let (imp, ty, wher) = generics.split_for_impl();
@@ -31,48 +40,48 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
 
     let before_transfer = no_hooks.is_present().not().then(|| {
         quote! {
-            let hook_state = <Self as near_contract_tools::standard::nep141::Nep141Hook::<_>>::before_transfer(self, &transfer);
+            let hook_state = <Self as #me::standard::nep141::Nep141Hook::<_>>::before_transfer(self, &transfer);
         }
     });
 
     let after_transfer = no_hooks.is_present().not().then(|| {
         quote! {
-            <Self as near_contract_tools::standard::nep141::Nep141Hook::<_>>::after_transfer(self, &transfer, hook_state);
+            <Self as #me::standard::nep141::Nep141Hook::<_>>::after_transfer(self, &transfer, hook_state);
         }
     });
 
     Ok(quote! {
-        use ::near_contract_tools::standard::nep141::Nep141Controller;
+        use #me::standard::nep141::Nep141Controller;
 
-        impl #imp ::near_contract_tools::standard::nep141::Nep141Controller for #ident #ty #wher {
-            fn root() -> ::near_contract_tools::slot::Slot<()> {
-                ::near_contract_tools::slot::Slot::root(#storage_key)
+        impl #imp #me::standard::nep141::Nep141Controller for #ident #ty #wher {
+            fn root() -> #me::slot::Slot<()> {
+                #me::slot::Slot::root(#storage_key)
             }
         }
 
-        use ::near_contract_tools::standard::nep141::Nep141;
+        use #me::standard::nep141::Nep141;
 
-        #[::near_sdk::near_bindgen]
-        impl #imp ::near_contract_tools::standard::nep141::Nep141 for #ident #ty #wher {
+        #[#near_sdk::near_bindgen]
+        impl #imp #me::standard::nep141::Nep141 for #ident #ty #wher {
             #[payable]
             fn ft_transfer(
                 &mut self,
-                receiver_id: ::near_sdk::AccountId,
-                amount: ::near_sdk::json_types::U128,
+                receiver_id: #near_sdk::AccountId,
+                amount: #near_sdk::json_types::U128,
                 memo: Option<String>,
             ) {
-                use ::near_contract_tools::{
+                use #me::{
                     standard::{
                         nep141::{Nep141Controller, Nep141Event},
                         nep297::Event,
                     },
                 };
 
-                ::near_sdk::assert_one_yocto();
-                let sender_id = ::near_sdk::env::predecessor_account_id();
+                #near_sdk::assert_one_yocto();
+                let sender_id = #near_sdk::env::predecessor_account_id();
                 let amount: u128 = amount.into();
 
-                let transfer = ::near_contract_tools::standard::nep141::Nep141Transfer {
+                let transfer = #me::standard::nep141::Nep141Transfer {
                     sender_id: sender_id.clone(),
                     receiver_id: receiver_id.clone(),
                     amount,
@@ -90,16 +99,16 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
             #[payable]
             fn ft_transfer_call(
                 &mut self,
-                receiver_id: ::near_sdk::AccountId,
-                amount: ::near_sdk::json_types::U128,
+                receiver_id: #near_sdk::AccountId,
+                amount: #near_sdk::json_types::U128,
                 memo: Option<String>,
                 msg: String,
-            ) -> ::near_sdk::Promise {
-                ::near_sdk::assert_one_yocto();
-                let sender_id = ::near_sdk::env::predecessor_account_id();
+            ) -> #near_sdk::Promise {
+                #near_sdk::assert_one_yocto();
+                let sender_id = #near_sdk::env::predecessor_account_id();
                 let amount: u128 = amount.into();
 
-                let transfer = ::near_contract_tools::standard::nep141::Nep141Transfer {
+                let transfer = #me::standard::nep141::Nep141Transfer {
                     sender_id: sender_id.clone(),
                     receiver_id: receiver_id.clone(),
                     amount,
@@ -109,14 +118,14 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
 
                 #before_transfer
 
-                let r = ::near_contract_tools::standard::nep141::Nep141Controller::transfer_call(
+                let r = #me::standard::nep141::Nep141Controller::transfer_call(
                     self,
                     sender_id.clone(),
                     receiver_id.clone(),
                     amount,
                     memo.as_deref(),
                     msg.clone(),
-                    near_sdk::env::prepaid_gas(),
+                    #near_sdk::env::prepaid_gas(),
                 );
 
                 #after_transfer
@@ -124,27 +133,27 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
                 r
             }
 
-            fn ft_total_supply(&self) -> ::near_sdk::json_types::U128 {
-                <Self as ::near_contract_tools::standard::nep141::Nep141Controller>::total_supply().into()
+            fn ft_total_supply(&self) -> #near_sdk::json_types::U128 {
+                <Self as #me::standard::nep141::Nep141Controller>::total_supply().into()
             }
 
-            fn ft_balance_of(&self, account_id: ::near_sdk::AccountId) -> near_sdk::json_types::U128 {
-                <Self as ::near_contract_tools::standard::nep141::Nep141Controller>::balance_of(&account_id).into()
+            fn ft_balance_of(&self, account_id: #near_sdk::AccountId) -> #near_sdk::json_types::U128 {
+                <Self as #me::standard::nep141::Nep141Controller>::balance_of(&account_id).into()
             }
         }
 
-        use ::near_contract_tools::standard::nep141::Nep141Resolver;
+        use #me::standard::nep141::Nep141Resolver;
 
-        #[::near_sdk::near_bindgen]
-        impl #imp ::near_contract_tools::standard::nep141::Nep141Resolver for #ident #ty #wher {
+        #[#near_sdk::near_bindgen]
+        impl #imp #me::standard::nep141::Nep141Resolver for #ident #ty #wher {
             #[private]
             fn ft_resolve_transfer(
                 &mut self,
-                sender_id: ::near_sdk::AccountId,
-                receiver_id: ::near_sdk::AccountId,
-                amount: ::near_sdk::json_types::U128,
-            ) -> ::near_sdk::json_types::U128 {
-                ::near_contract_tools::standard::nep141::Nep141Controller::resolve_transfer(self, sender_id, receiver_id, amount.into()).into()
+                sender_id: #near_sdk::AccountId,
+                receiver_id: #near_sdk::AccountId,
+                amount: #near_sdk::json_types::U128,
+            ) -> #near_sdk::json_types::U128 {
+                #me::standard::nep141::Nep141Controller::resolve_transfer(self, sender_id, receiver_id, amount.into()).into()
             }
         }
     })

--- a/macros/src/standard/nep148.rs
+++ b/macros/src/standard/nep148.rs
@@ -15,6 +15,12 @@ pub struct Nep148Meta {
 
     pub generics: syn::Generics,
     pub ident: syn::Ident,
+
+    // crates
+    #[darling(rename = "crate", default = "crate::default_crate_name")]
+    pub me: syn::Path,
+    #[darling(default = "crate::default_near_sdk")]
+    pub near_sdk: syn::Path,
 }
 
 fn optionize<T>(t: Option<T>) -> TokenStream
@@ -36,11 +42,14 @@ pub fn expand(meta: Nep148Meta) -> Result<TokenStream, darling::Error> {
         reference,
         reference_hash,
         decimals,
+
+        me,
+        near_sdk,
     } = meta;
 
     let spec = spec.map(|s| s.to_token_stream()).unwrap_or_else(|| {
         quote! {
-            near_contract_tools::standard::nep148::FT_METADATA_SPEC
+            #me::standard::nep148::FT_METADATA_SPEC
         }
     });
 
@@ -53,17 +62,17 @@ pub fn expand(meta: Nep148Meta) -> Result<TokenStream, darling::Error> {
             .parse::<quote::__private::TokenStream>()
             .unwrap();
 
-        quote! { ::std::borrow::Cow::Owned(::near_sdk::json_types::Base64VecU8::from(#v.to_vec())) }
+        quote! { ::std::borrow::Cow::Owned(#near_sdk::json_types::Base64VecU8::from(#v.to_vec())) }
     }));
 
     let (imp, ty, wher) = generics.split_for_impl();
 
     Ok(quote! {
-        use near_contract_tools::standard::nep148::Nep148;
-        #[::near_sdk::near_bindgen]
-        impl #imp ::near_contract_tools::standard::nep148::Nep148 for #ident #ty #wher {
-            fn ft_metadata(&self) -> ::near_contract_tools::standard::nep148::FungibleTokenMetadata<'static> {
-                ::near_contract_tools::standard::nep148::FungibleTokenMetadata {
+        use #me::standard::nep148::Nep148;
+        #[#near_sdk::near_bindgen]
+        impl #imp #me::standard::nep148::Nep148 for #ident #ty #wher {
+            fn ft_metadata(&self) -> #me::standard::nep148::FungibleTokenMetadata<'static> {
+                #me::standard::nep148::FungibleTokenMetadata {
                     spec: #spec.into(),
                     name: #name.into(),
                     symbol: #symbol.into(),

--- a/macros/src/standard/nep297.rs
+++ b/macros/src/standard/nep297.rs
@@ -14,6 +14,10 @@ pub struct Nep297Meta {
     pub ident: syn::Ident,
     pub generics: syn::Generics,
     pub data: darling::ast::Data<EventVariantReceiver, ()>,
+
+    // crates
+    #[darling(rename = "crate", default = "crate::default_crate_name")]
+    pub me: syn::Path,
 }
 
 #[derive(Debug, FromVariant)]
@@ -33,6 +37,7 @@ pub fn expand(meta: Nep297Meta) -> Result<TokenStream, darling::Error> {
         ident: type_name,
         generics,
         data,
+        me,
     } = meta;
 
     let (imp, ty, wher) = generics.split_for_impl();
@@ -74,7 +79,7 @@ pub fn expand(meta: Nep297Meta) -> Result<TokenStream, darling::Error> {
     .collect::<Vec<_>>();
 
     Ok(quote! {
-        impl #imp near_contract_tools::standard::nep297::EventMetadata for #type_name #ty #wher {
+        impl #imp #me::standard::nep297::EventMetadata for #type_name #ty #wher {
             fn standard(&self) -> &'static str {
                 #standard
             }
@@ -95,7 +100,7 @@ pub fn expand(meta: Nep297Meta) -> Result<TokenStream, darling::Error> {
                 write!(
                     f,
                     "{}",
-                    near_contract_tools::standard::nep297::Event::to_event_string(self),
+                    #me::standard::nep297::Event::to_event_string(self),
                 )
             }
         }

--- a/src/approval/mod.rs
+++ b/src/approval/mod.rs
@@ -296,8 +296,7 @@ mod tests {
     };
     use serde::Serialize;
 
-    use crate::rbac::Rbac;
-    use crate::{near_contract_tools, slot::Slot};
+    use crate::{rbac::Rbac, slot::Slot};
 
     use super::{Action, ActionRequest, ApprovalConfiguration, ApprovalManager};
 
@@ -330,7 +329,7 @@ mod tests {
     }
 
     #[derive(Rbac)]
-    #[rbac(roles = "Role")]
+    #[rbac(roles = "Role", crate = "crate")]
     #[near_bindgen]
     struct Contract {}
 

--- a/src/approval/simple_multisig.rs
+++ b/src/approval/simple_multisig.rs
@@ -218,7 +218,6 @@ mod tests {
             simple_multisig::{AccountAuthorizer, ApprovalState, Configuration},
             ApprovalManager,
         },
-        near_contract_tools,
         rbac::Rbac,
         slot::Slot,
         Rbac,
@@ -247,7 +246,7 @@ mod tests {
     }
 
     #[derive(Rbac, Debug, BorshSerialize, BorshDeserialize)]
-    #[rbac(roles = "Role")]
+    #[rbac(roles = "Role", crate = "crate")]
     #[near_bindgen]
     struct Contract {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,3 @@ pub mod slot;
 pub mod utils;
 
 pub use near_contract_tools_macros::*;
-
-mod near_contract_tools {
-    pub use super::*;
-}

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -3,7 +3,7 @@
 
 use near_sdk::{env, ext_contract, require, AccountId};
 
-use crate::{event, near_contract_tools, slot::Slot, standard::nep297::Event};
+use crate::{event, slot::Slot, standard::nep297::Event};
 
 const ONLY_OWNER_FAIL_MESSAGE: &str = "Owner only";
 const OWNER_INIT_FAIL_MESSAGE: &str = "Owner already initialized";
@@ -12,7 +12,12 @@ const ONLY_PROPOSED_OWNER_FAIL_MESSAGE: &str = "Proposed owner only";
 const NO_PROPOSED_OWNER_FAIL_MESSAGE: &str = "No proposed owner";
 
 /// Events emitted by function calls on an ownable contract
-#[event(standard = "x-own", version = "1.0.0")]
+#[event(
+    standard = "x-own",
+    version = "1.0.0",
+    crate = "crate",
+    macros = "near_contract_tools_macros"
+)]
 pub enum OwnerEvent {
     /// Emitted when the current owner of the contract changes
     Transfer {
@@ -245,11 +250,8 @@ mod tests {
         Owner,
     };
 
-    mod near_contract_tools {
-        pub use crate::*;
-    }
-
     #[derive(Owner)]
+    #[owner(crate = "crate")]
     #[near_bindgen]
     struct Contract {}
 

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -1,14 +1,19 @@
 //! Contract method pausing/unpausing
 #![allow(missing_docs)] // #[ext_contract(...)] does not play nicely with clippy
 
-use crate::{event, near_contract_tools, slot::Slot, standard::nep297::Event};
+use crate::{event, slot::Slot, standard::nep297::Event};
 use near_sdk::{ext_contract, require};
 
 const UNPAUSED_FAIL_MESSAGE: &str = "Disallowed while contract is unpaused";
 const PAUSED_FAIL_MESSAGE: &str = "Disallowed while contract is paused";
 
 /// Events emitted when contract pause state is changed
-#[event(standard = "x-paus", version = "1.0.0")]
+#[event(
+    standard = "x-paus",
+    version = "1.0.0",
+    crate = "crate",
+    macros = "near_contract_tools_macros"
+)]
 pub enum PauseEvent {
     /// Emitted when the contract is paused
     Pause,

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -82,7 +82,7 @@ mod tests {
     }
 
     #[derive(Rbac)]
-    #[rbac(roles = "Role")]
+    #[rbac(roles = "Role", crate = "crate")]
     #[near_bindgen]
     struct Contract {}
 

--- a/src/standard/nep141.rs
+++ b/src/standard/nep141.rs
@@ -10,7 +10,7 @@ use near_sdk::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{event, near_contract_tools, slot::Slot, standard::nep297::Event};
+use crate::{event, slot::Slot, standard::nep297::Event};
 
 /// Gas value required for ft_resolve_transfer calls
 pub const GAS_FOR_RESOLVE_TRANSFER: Gas = Gas(5_000_000_000_000);
@@ -20,7 +20,13 @@ pub const GAS_FOR_FT_TRANSFER_CALL: Gas = Gas(25_000_000_000_000 + GAS_FOR_RESOL
 const MORE_GAS_FAIL_MESSAGE: &str = "More gas is required";
 
 /// NEP-141 standard events for minting, burning, and transferring tokens
-#[event(standard = "nep141", version = "1.0.0")]
+#[event(
+    crate = "crate",
+    macros = "crate",
+    serde = "serde",
+    standard = "nep141",
+    version = "1.0.0"
+)]
 pub enum Nep141Event<'a> {
     /// Token mint event. Emitted when tokens are created and total_supply is
     /// increased.


### PR DESCRIPTION
serde uses this nifty field on their macros to allow you to specify the actual crate it should be using as the "serde" crate:

```rs
#[serde(crate = "path::to::serde")]
```

Emulating this pattern is useful:
 - Currently there is an inconsistent use of leading colons `::` in the macros
 - It's weird to try to use the `near_contract_tools_macros` in `near_contract_tools` for this reason
 - Some macros make use of other crates' types (`near_sdk` and `serde`, particularly). `near_sdk` reexports its own version of `serde`, so some users may wish to use that version (also we should discuss what the default serde crate should be @ryancwalsh @nearken).