### PR TITLE
`#[no_std]` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Jacob Lindahl <jacob@near.foundation>"]
-categories = ["wasm", "cryptography::cryptocurrencies"]
+categories = ["wasm", "cryptography::cryptocurrencies", "no-std"]
 description = """
 Helpful functions and macros for developing smart contracts on NEAR Protocol.
 """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ near-contract-tools-macros = {version = "=0.6.1", path = "./macros"}
 near-sdk = "4.0.0"
 serde = "1.0.144"
 serde_json = "1.0.85"
-thiserror = "1.0.35"
+snafu = "0.7.1"
 
 [workspace]
 members = [

--- a/macros/src/approval/simple_multisig.rs
+++ b/macros/src/approval/simple_multisig.rs
@@ -59,7 +59,7 @@ pub fn expand(meta: SimpleMultisigMeta) -> Result<TokenStream, darling::Error> {
                 if <#ident as #me::rbac::Rbac>::has_role(account_id, &#role) {
                     Ok(())
                 } else {
-                    Err(#me::approval::simple_multisig::macro_types::MissingRole(#role))
+                    Err(#me::approval::simple_multisig::macro_types::MissingRole { role: #role })
                 }
             }
         }

--- a/src/approval/native_transaction_action.rs
+++ b/src/approval/native_transaction_action.rs
@@ -2,6 +2,8 @@
 //! delete account, add key, delete key, deploy contract, function call, stake,
 //! transfer)
 
+use alloc::string::String;
+use alloc::vec::Vec;
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
     json_types::{U128, U64},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate alloc;
 
 pub mod standard;
 

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,6 +1,7 @@
 //! Migrate default struct between two schemas
 #![allow(missing_docs)] // #[ext_contract(...)] does not play nicely with clippy
 
+use alloc::string::{String, ToString};
 use near_sdk::{
     borsh::{BorshDeserialize, BorshSerialize},
     env, ext_contract,

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -1,6 +1,8 @@
 //! Owner pattern
 #![allow(missing_docs)] // #[ext_contract(...)] does not play nicely with clippy
 
+use alloc::{string::ToString, vec};
+
 use near_sdk::{env, ext_contract, require, AccountId};
 
 use crate::{slot::Slot, standard::nep297::Event};
@@ -254,6 +256,7 @@ pub trait OwnerExternal {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{string::ToString, vec};
     use near_sdk::{near_bindgen, test_utils::VMContextBuilder, testing_env, AccountId};
 
     use crate::{

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -2,6 +2,7 @@
 #![allow(missing_docs)] // #[ext_contract(...)] does not play nicely with clippy
 
 use crate::{slot::Slot, standard::nep297::Event};
+use alloc::{string::ToString, vec};
 use near_sdk::{ext_contract, require};
 
 const UNPAUSED_FAIL_MESSAGE: &str = "Disallowed while contract is unpaused";

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -3,8 +3,9 @@
 //! Makes it easier to avoid storing storage keys in storage itself, helping to
 //! reduce IO in a transaction and save on gas.
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
+use alloc::vec::Vec;
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
     env, IntoStorageKey,

--- a/src/standard/nep141.rs
+++ b/src/standard/nep141.rs
@@ -2,6 +2,8 @@
 //! <https://github.com/near/NEPs/blob/master/neps/nep-0141.md>
 #![allow(missing_docs)] // ext_contract doesn't play nice with #![warn(missing_docs)]
 
+use alloc::string::{String, ToString};
+use alloc::vec;
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
     env, ext_contract,
@@ -415,7 +417,7 @@ pub trait Nep141Controller {
             PromiseResult::NotReady => env::abort(),
             PromiseResult::Successful(value) => {
                 if let Ok(U128(unused_amount)) = serde_json::from_slice::<U128>(&value) {
-                    std::cmp::min(amount, unused_amount)
+                    core::cmp::min(amount, unused_amount)
                 } else {
                     amount
                 }
@@ -426,7 +428,7 @@ pub trait Nep141Controller {
         let refunded_amount = if unused_amount > 0 {
             let receiver_balance = Self::balance_of(&receiver_id);
             if receiver_balance > 0 {
-                let refund_amount = std::cmp::min(receiver_balance, unused_amount);
+                let refund_amount = core::cmp::min(receiver_balance, unused_amount);
                 self.transfer(&receiver_id, &sender_id, refund_amount, None);
                 refund_amount
             } else {

--- a/src/standard/nep148.rs
+++ b/src/standard/nep148.rs
@@ -2,7 +2,7 @@
 //! <https://github.com/near/NEPs/blob/master/neps/nep-0148.md>
 #![allow(missing_docs)] // ext_contract doesn't play nice with #![warn(missing_docs)]
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::ToString, vec};
 
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
@@ -45,9 +45,10 @@ pub trait Nep148 {
 
 #[cfg(test)]
 mod tests {
+    use crate::alloc::borrow::ToOwned;
     use crate::standard::nep148::FungibleTokenMetadata;
+    use alloc::borrow::Cow;
     use near_sdk::borsh::BorshSerialize;
-    use std::borrow::Cow;
 
     #[test]
     fn borsh_serialization_ignores_cow() {

--- a/src/standard/nep297.rs
+++ b/src/standard/nep297.rs
@@ -1,5 +1,6 @@
 //! Helpers for `#[derive(near_contract_tools::Nep297)]`
 
+use alloc::{format, string::String};
 use near_sdk::serde::Serialize;
 
 /// Emit events according to the [NEP-297 event standard](https://nomicon.io/Standards/EventsFormat).

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 //! Utility functions for storage key generation, storage fee management
 
+use alloc::{format, vec::Vec};
 use near_sdk::{env, require, Promise};
 
 /// Concatenate bytes to form a key. Useful for generating storage keys.

--- a/workspaces-tests/src/bin/native_multisig.rs
+++ b/workspaces-tests/src/bin/native_multisig.rs
@@ -16,8 +16,10 @@ use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
     env, near_bindgen, AccountId, BorshStorageKey, PanicOnDefault, Promise,
 };
+use std::string::ToString;
+use strum_macros::Display;
 
-#[derive(Clone, Debug, BorshSerialize, BorshStorageKey)]
+#[derive(Display, Clone, Debug, BorshSerialize, BorshStorageKey)]
 pub enum Role {
     Multisig,
 }


### PR DESCRIPTION
Experimental. Let's see if `near-contract-tools` can be `#[no_std]`!