### PR TITLE
Events overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ fn own_accept_owner(&mut self);
 
 ### Events
 
+The `#[event]` macro can be applied to structs or enums.
+
 ```rust
 use near_contract_tools::{event, standard::nep297::Event};
 

--- a/macros/src/migrate.rs
+++ b/macros/src/migrate.rs
@@ -46,7 +46,7 @@ pub fn expand(meta: MigrateMeta) -> Result<TokenStream, darling::Error> {
         impl #imp #me::migrate::MigrateExternal for #ident #ty #wh {
             #[init(ignore_state)]
             fn migrate() -> Self {
-                let old_state = <#ident as ::near_contract_tools::migrate::MigrateController>::deserialize_old_schema();
+                let old_state = <#ident as #me::migrate::MigrateController>::deserialize_old_schema();
                 <#ident as #me::migrate::MigrateHook>::on_migrate(
                     old_state,
                 )

--- a/macros/src/standard/nep141.rs
+++ b/macros/src/standard/nep141.rs
@@ -87,7 +87,13 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
 
                 #before_transfer
 
-                Nep141Controller::transfer(self, &sender_id, &receiver_id, amount, memo.as_deref());
+                Nep141Controller::transfer(
+                    self,
+                    sender_id.clone(),
+                    receiver_id.clone(),
+                    amount,
+                    memo,
+                );
 
                 #after_transfer
             }
@@ -119,7 +125,7 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
                     sender_id.clone(),
                     receiver_id.clone(),
                     amount,
-                    memo.as_deref(),
+                    memo,
                     msg.clone(),
                     #near_sdk::env::prepaid_gas(),
                 );
@@ -147,7 +153,12 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
                 receiver_id: #near_sdk::AccountId,
                 amount: #near_sdk::json_types::U128,
             ) -> #near_sdk::json_types::U128 {
-                #me::standard::nep141::Nep141Controller::resolve_transfer(self, sender_id, receiver_id, amount.into()).into()
+                #me::standard::nep141::Nep141Controller::resolve_transfer(
+                    self,
+                    sender_id,
+                    receiver_id,
+                    amount.into(),
+                ).into()
             }
         }
     })

--- a/macros/src/standard/nep297.rs
+++ b/macros/src/standard/nep297.rs
@@ -127,8 +127,10 @@ pub fn expand(meta: Nep297Meta) -> Result<TokenStream, darling::Error> {
     };
 
     Ok(quote! {
-        impl #imp #me::standard::nep297::Event<#ident #ty> for #ident #ty #wher {
-            fn event_log<'__el>(&'__el self) -> #me::standard::nep297::EventLog<&'__el Self> {
+        impl #imp #me::standard::nep297::ToEventLog for #ident #ty #wher {
+            type Data = #ident #ty;
+
+            fn to_event_log<'__el>(&'__el self) -> #me::standard::nep297::EventLog<&'__el Self> {
                 #me::standard::nep297::EventLog {
                     standard: #standard,
                     version: #version,

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -2,34 +2,25 @@
 #![allow(missing_docs)] // #[ext_contract(...)] does not play nicely with clippy
 
 use crate::{slot::Slot, standard::nep297::Event};
+use near_contract_tools_macros::event;
 use near_sdk::{ext_contract, require};
 
 const UNPAUSED_FAIL_MESSAGE: &str = "Disallowed while contract is unpaused";
 const PAUSED_FAIL_MESSAGE: &str = "Disallowed while contract is paused";
 
 /// Events emitted when contract pause state is changed
-pub mod event {
-    use crate::event;
-
+#[event(
+    standard = "x-paus",
+    version = "1.0.0",
+    crate = "crate",
+    macros = "near_contract_tools_macros"
+)]
+#[derive(Debug, Clone)]
+pub enum PauseEvent {
     /// Emitted when the contract is paused
-    #[event(
-        standard = "x-paus",
-        version = "1.0.0",
-        crate = "crate",
-        macros = "near_contract_tools_macros"
-    )]
-    #[derive(Debug, Clone)]
-    pub struct Pause;
-
+    Pause,
     /// Emitted when the contract is unpaused
-    #[event(
-        standard = "x-paus",
-        version = "1.0.0",
-        crate = "crate",
-        macros = "near_contract_tools_macros"
-    )]
-    #[derive(Debug, Clone)]
-    pub struct Unpause;
+    Unpause,
 }
 
 /// Internal-only interactions for a pausable contract
@@ -90,7 +81,7 @@ pub trait Pause {
     fn pause(&mut self) {
         Self::require_unpaused();
         self.set_is_paused(true);
-        event::Pause.emit();
+        PauseEvent::Pause.emit();
     }
 
     /// Unpauses the contract if it is currently paused, panics otherwise.
@@ -98,7 +89,7 @@ pub trait Pause {
     fn unpause(&mut self) {
         Self::require_paused();
         self.set_is_paused(false);
-        event::Unpause.emit();
+        PauseEvent::Unpause.emit();
     }
 
     /// Rejects if the contract is unpaused

--- a/src/standard/nep297.rs
+++ b/src/standard/nep297.rs
@@ -26,28 +26,37 @@ use near_sdk::serde::Serialize;
 ///
 /// e.emit();
 /// ```
-pub trait Event<T: ?Sized> {
-    /// Retrieves the event log before serialization
-    fn event_log(&self) -> EventLog<&T>;
-
+pub trait Event {
     /// Converts the event into an NEP-297 event-formatted string
-    fn to_event_string(&self) -> String
-    where
-        T: Serialize,
-    {
+    fn to_event_string(&self) -> String;
+
+    /// Emits the event string to the blockchain
+    fn emit(&self);
+}
+
+impl<T: ToEventLog> Event for T
+where
+    T::Data: Serialize,
+{
+    fn to_event_string(&self) -> String {
         format!(
             "EVENT_JSON:{}",
-            serde_json::to_string(&self.event_log()).unwrap_or_else(|_| near_sdk::env::abort()),
+            serde_json::to_string(&self.to_event_log()).unwrap_or_else(|_| near_sdk::env::abort()),
         )
     }
 
-    /// Emits the event string to the blockchain
-    fn emit(&self)
-    where
-        T: Serialize,
-    {
+    fn emit(&self) {
         near_sdk::env::log_str(&self.to_event_string());
     }
+}
+
+/// This type can be converted into an [`EventLog`] struct
+pub trait ToEventLog {
+    /// Metadata associated with the event
+    type Data: ?Sized;
+
+    /// Retrieves the event log before serialization
+    fn to_event_log(&self) -> EventLog<&Self::Data>;
 }
 
 /// NEP-297 Event Log Data

--- a/tests/macros/event.rs
+++ b/tests/macros/event.rs
@@ -1,4 +1,4 @@
-use near_contract_tools::standard::nep297::Event;
+use near_contract_tools::standard::nep297::{Event, ToEventLog};
 
 use crate::macros::event::test_events::Nep171NftMintData;
 
@@ -66,35 +66,43 @@ fn derive_event() {
         r#"EVENT_JSON:{"standard":"nep171","version":"1.0.0","event":"nft_mint","data":[{"owner_id":"owner","token_ids":["token_1","token_2"]}]}"#
     );
 
-    assert_eq!(test_events::AnotherEvent.event_log().event, "sneaky_event");
-    assert_eq!(test_events::CustomEvent.event_log().event, "CUSTOM-EVENT");
     assert_eq!(
-        test_events::EnumEvent::VariantOne.event_log().event,
+        test_events::AnotherEvent.to_event_log().event,
+        "sneaky_event"
+    );
+    assert_eq!(
+        test_events::CustomEvent.to_event_log().event,
+        "CUSTOM-EVENT"
+    );
+    assert_eq!(
+        test_events::EnumEvent::VariantOne.to_event_log().event,
         "VariantOne"
     );
     assert_eq!(
-        test_events::EnumEvent::VariantTwo().event_log().event,
+        test_events::EnumEvent::VariantTwo().to_event_log().event,
         "genuine_variant_two"
     );
     assert_eq!(
-        test_events::EnumEvent::VariantThree(0, 0).event_log().event,
+        test_events::EnumEvent::VariantThree(0, 0)
+            .to_event_log()
+            .event,
         "VARIANT_THREE"
     );
     assert_eq!(
         test_events::EnumEventRenameAll::VariantOne
-            .event_log()
+            .to_event_log()
             .event,
         "variant_one"
     );
     assert_eq!(
         test_events::EnumEventRenameAll::VariantTwo
-            .event_log()
+            .to_event_log()
             .event,
         "variantTwo"
     );
     assert_eq!(
         test_events::EnumEventRenameAll::VariantThree
-            .event_log()
+            .to_event_log()
             .event,
         "threedom!"
     );
@@ -117,6 +125,7 @@ mod event_attribute_macro {
     }
 
     #[event(standard = "my_event_standard", version = "1")]
+    #[allow(unused)]
     enum MyEvent {
         One,
         ThreePointFive { foo: &'static str },


### PR DESCRIPTION
This (yet again) an overhaul of the event system. From the outside, it looks pretty much the same (except for I've converted the pattern events back to enums for conciseness). However, now there are two traits for the event system:
1. `ToEventLog`: Returns a serializable `EventLog` struct that contains generic metadata.
2. `Event`: Only contains the methods `to_event_string` and `emit`. No generics. This is the trait that generic functions that accept events as arguments should target. For example:
    ```rs
    fn my_function(e: impl Event) {
        // ...
    }
    ```
Anything that implements `ToEventLog` automatically implements `Event`. Separating these two also allows others to write their own custom `Event`s without being forced to go through our `EventLog` conversion (if they want to).