### PR TITLE
Default storage keys enum

### DIFF
--- a/macros/src/approval/simple_multisig.rs
+++ b/macros/src/approval/simple_multisig.rs
@@ -3,8 +3,6 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Expr;
 
-const DEFAULT_STORAGE_KEY: &str = r#"(b"~sm" as &[u8])"#;
-
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(simple_multisig), supports(struct_named))]
 pub struct SimpleMultisigMeta {
@@ -35,8 +33,13 @@ pub fn expand(meta: SimpleMultisigMeta) -> Result<TokenStream, darling::Error> {
 
     let (imp, ty, wher) = generics.split_for_impl();
 
-    let storage_key =
-        storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
+    let root = storage_key.map(|storage_key| {
+        quote! {
+            fn root() -> #me::slot::Slot<()> {
+                #me::slot::Slot::root(#storage_key)
+            }
+        }
+    });
 
     Ok(quote! {
         impl #imp #me::approval::ApprovalManager<
@@ -44,9 +47,7 @@ pub fn expand(meta: SimpleMultisigMeta) -> Result<TokenStream, darling::Error> {
                 #me::approval::simple_multisig::ApprovalState,
                 #me::approval::simple_multisig::Configuration<Self>,
             > for #ident #ty #wher {
-            fn root() -> #me::slot::Slot<()> {
-                #me::slot::Slot::root(#storage_key)
-            }
+            #root
         }
 
         impl #imp #me::approval::simple_multisig::AccountAuthorizer for #ident #ty #wher {

--- a/macros/src/pause.rs
+++ b/macros/src/pause.rs
@@ -3,8 +3,6 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Expr;
 
-const DEFAULT_STORAGE_KEY: &str = r#"(b"~p" as &[u8])"#;
-
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(pause), supports(struct_named))]
 pub struct PauseMeta {
@@ -32,14 +30,17 @@ pub fn expand(meta: PauseMeta) -> Result<TokenStream, darling::Error> {
 
     let (imp, ty, wher) = generics.split_for_impl();
 
-    let storage_key =
-        storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
-
-    Ok(quote! {
-        impl #imp #me::pause::Pause for #ident #ty #wher {
+    let root = storage_key.map(|storage_key| {
+        quote! {
             fn root() -> #me::slot::Slot<()> {
                 #me::slot::Slot::new(#storage_key)
             }
+        }
+    });
+
+    Ok(quote! {
+        impl #imp #me::pause::Pause for #ident #ty #wher {
+            #root
         }
 
         #[#near_sdk::near_bindgen]

--- a/macros/src/rbac.rs
+++ b/macros/src/rbac.rs
@@ -3,8 +3,6 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Expr;
 
-const DEFAULT_STORAGE_KEY: &str = r#"(b"~r" as &[u8])"#;
-
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(rbac), supports(struct_named))]
 pub struct RbacMeta {
@@ -33,16 +31,19 @@ pub fn expand(meta: RbacMeta) -> Result<TokenStream, darling::Error> {
 
     let (imp, ty, wher) = generics.split_for_impl();
 
-    let storage_key =
-        storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
+    let root = storage_key.map(|storage_key| {
+        quote! {
+            fn root() -> #me::slot::Slot<()> {
+                #me::slot::Slot::new(#storage_key)
+            }
+        }
+    });
 
     Ok(quote! {
         impl #imp #me::rbac::Rbac for #ident #ty #wher {
             type Role = #roles;
 
-            fn root() -> #me::slot::Slot<()> {
-                #me::slot::Slot::new(#storage_key)
-            }
+            #root
         }
     })
 }

--- a/src/approval/mod.rs
+++ b/src/approval/mod.rs
@@ -7,7 +7,7 @@ use near_sdk::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::slot::Slot;
+use crate::{slot::Slot, DefaultStorageKey};
 
 /// Error message emitted when the component is used before it is initialized
 pub const NOT_INITIALIZED: &str = "init must be called before use";
@@ -134,7 +134,9 @@ where
     C: ApprovalConfiguration<A, S> + BorshDeserialize + BorshSerialize,
 {
     /// Storage root
-    fn root() -> Slot<()>;
+    fn root() -> Slot<()> {
+        Slot::new(DefaultStorageKey::ApprovalManager)
+    }
 
     /// Because requests will be deleted from the requests collection,
     /// maintain a simple counter to guarantee unique IDs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,32 @@
 #![doc = include_str!("../README.md")]
 
+/// Default storage keys used by various traits' `root()` functions.
+#[derive(Clone, Debug)]
+pub enum DefaultStorageKey {
+    /// Default storage key for [`ApprovalManager`]
+    ApprovalManager,
+    /// Default storage key for [`Nep141Controller`]
+    Nep141,
+    /// Default storage key for [`Owner`]
+    Owner,
+    /// Default storage key for [`Pause`]
+    Pause,
+    /// Default storage key for [`Rbac`]
+    Rbac,
+}
+
+impl IntoStorageKey for DefaultStorageKey {
+    fn into_storage_key(self) -> Vec<u8> {
+        match self {
+            DefaultStorageKey::ApprovalManager => b"~am".to_vec(),
+            DefaultStorageKey::Nep141 => b"~$141".to_vec(),
+            DefaultStorageKey::Owner => b"~o".to_vec(),
+            DefaultStorageKey::Pause => b"~p".to_vec(),
+            DefaultStorageKey::Rbac => b"~r".to_vec(),
+        }
+    }
+}
+
 pub mod standard;
 
 pub mod approval;
@@ -12,3 +39,4 @@ pub mod upgrade;
 pub mod utils;
 
 pub use near_contract_tools_macros::*;
+use near_sdk::IntoStorageKey;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,15 @@
 /// Default storage keys used by various traits' `root()` functions.
 #[derive(Clone, Debug)]
 pub enum DefaultStorageKey {
-    /// Default storage key for [`ApprovalManager`]
+    /// Default storage key for [`approval::ApprovalManager::root`]
     ApprovalManager,
-    /// Default storage key for [`Nep141Controller`]
+    /// Default storage key for [`standard::nep141::Nep141Controller::root`]
     Nep141,
-    /// Default storage key for [`Owner`]
+    /// Default storage key for [`owner::Owner::root`]
     Owner,
-    /// Default storage key for [`Pause`]
+    /// Default storage key for [`pause::Pause::root`]
     Pause,
-    /// Default storage key for [`Rbac`]
+    /// Default storage key for [`rbac::Rbac::root`]
     Rbac,
 }
 

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -38,7 +38,7 @@ use near_sdk::{
     env, ext_contract, require, AccountId, BorshStorageKey,
 };
 
-use crate::{slot::Slot, standard::nep297::Event};
+use crate::{slot::Slot, standard::nep297::Event, DefaultStorageKey};
 
 const ONLY_OWNER_FAIL_MESSAGE: &str = "Owner only";
 const OWNER_INIT_FAIL_MESSAGE: &str = "Owner already initialized";
@@ -81,7 +81,9 @@ enum StorageKey {
 /// A contract with an owner
 pub trait Owner {
     /// Storage root
-    fn root() -> Slot<()>;
+    fn root() -> Slot<()> {
+        Slot::new(DefaultStorageKey::Owner)
+    }
 
     /// Storage slot for initialization state
     fn slot_is_initialized() -> Slot<bool> {

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -23,7 +23,7 @@
 //! * (ERR) [`Pause::require_unpaused`] may only be called when the contract is unpaused.
 #![allow(missing_docs)] // #[ext_contract(...)] does not play nicely with clippy
 
-use crate::{slot::Slot, standard::nep297::Event};
+use crate::{slot::Slot, standard::nep297::Event, DefaultStorageKey};
 use near_contract_tools_macros::event;
 use near_sdk::{ext_contract, require};
 
@@ -80,7 +80,9 @@ pub enum PauseEvent {
 /// ```
 pub trait Pause {
     /// Storage root
-    fn root() -> Slot<()>;
+    fn root() -> Slot<()> {
+        Slot::new(DefaultStorageKey::Pause)
+    }
 
     /// Storage slot for pause state
     fn slot_paused() -> Slot<bool> {

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -27,7 +27,7 @@
 //!     account does not have the specified role.
 use near_sdk::{borsh::BorshSerialize, env, require, AccountId, IntoStorageKey};
 
-use crate::slot::Slot;
+use crate::{slot::Slot, DefaultStorageKey};
 
 const REQUIRE_ROLE_FAIL_MESSAGE: &str = "Unauthorized role";
 const PROHIBIT_ROLE_FAIL_MESSAGE: &str = "Prohibited role";
@@ -38,7 +38,9 @@ pub trait Rbac {
     type Role: BorshSerialize + IntoStorageKey;
 
     /// Storage slot namespace for items
-    fn root() -> Slot<()>;
+    fn root() -> Slot<()> {
+        Slot::new(DefaultStorageKey::Rbac)
+    }
 
     /// Returns whether a given account has been given a certain role.
     fn has_role(account_id: &AccountId, role: &Self::Role) -> bool {

--- a/src/standard/nep141.rs
+++ b/src/standard/nep141.rs
@@ -11,7 +11,7 @@ use near_sdk::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{slot::Slot, standard::nep297::*};
+use crate::{slot::Slot, standard::nep297::*, DefaultStorageKey};
 
 /// Gas value required for ft_resolve_transfer calls
 pub const GAS_FOR_RESOLVE_TRANSFER: Gas = Gas(5_000_000_000_000);
@@ -194,7 +194,9 @@ impl Nep141Transfer {
 /// Non-public implementations of functions for managing a fungible token.
 pub trait Nep141Controller {
     /// Root storage slot
-    fn root() -> Slot<()>;
+    fn root() -> Slot<()> {
+        Slot::new(DefaultStorageKey::Nep141)
+    }
 
     /// Slot for account data
     fn slot_account(account_id: &AccountId) -> Slot<u128> {


### PR DESCRIPTION
BREAKING CHANGE: Default storage key for implementations of `ApprovalManager` (e.g. simple multisig) changed from `~sm` to `~am`. Simple multisig now uses the default storage key for `ApprovalManager`s instead of having its own. I think this is safe, because the vast majority of projects that use an approval component will only use one.