### PR TITLE
fix: remove near-sdk default features usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,13 @@ version = "0.6.1"
 
 [dependencies]
 near-contract-tools-macros = {version = "=0.6.1", path = "./macros"}
-near-sdk = "4.1.0"
+near-sdk = { version = "4.1.0", default-features = false }
 serde = "1.0.144"
 serde_json = "1.0.85"
 thiserror = "1.0.35"
+
+[dev-dependencies]
+near-sdk = { version = "4.1.0", default-features = false, features = ["unit-testing", "legacy"] }
 
 [features]
 unstable = ["near-sdk/unstable"]

--- a/workspaces-tests/Cargo.toml
+++ b/workspaces-tests/Cargo.toml
@@ -40,7 +40,7 @@ name = "simple_multisig"
 
 [dependencies]
 near-contract-tools = {path = "../", features = ["unstable"]}
-near-sdk = "4.1.0"
+near-sdk = { version = "4.1.0", default-features = false }
 strum = "0.24.1"
 strum_macros = "0.24.3"
 thiserror = "1.0.34"

--- a/workspaces-tests/Cargo.toml
+++ b/workspaces-tests/Cargo.toml
@@ -40,7 +40,7 @@ name = "simple_multisig"
 
 [dependencies]
 near-contract-tools = {path = "../", features = ["unstable"]}
-near-sdk = { version = "4.1.0", default-features = false }
+near-sdk = { version = "4.1.1", default-features = false }
 strum = "0.24.1"
 strum_macros = "0.24.3"
 thiserror = "1.0.34"


### PR DESCRIPTION
Currently, doesn't allow a consumer to disable pulling in these features. This should only use what is needed.